### PR TITLE
Enhanced session attribution tracking by conditionally including new …

### DIFF
--- a/macros/base_select.sql
+++ b/macros/base_select.sql
@@ -35,7 +35,11 @@
     , ecommerce.unique_items
     , ecommerce.transaction_id
     , items
+    {% if var('start_date', '20240101') >= '20240717' %}
+    -- session_traffic_source_last_click was introduced on 2024-07-17 to enhance attribution tracking
+    -- This field provides more detailed session-level attribution data compared to the standard traffic_source
     , session_traffic_source_last_click
+    {% endif %}
     , collected_traffic_source
     , {%- if  var('combined_dataset', false) != false %} cast(left(regexp_replace(_table_suffix, r'^(intraday_)?\d{8}', ''), 100) as int64)
         {%- else %} {{ var('property_ids')[0] }}
@@ -95,6 +99,8 @@
     , traffic_source.name as user_campaign
     , traffic_source.medium as user_medium
     , traffic_source.source as user_source
+    {% if var('start_date', '20240101') >= '20240717' %}
+    -- The following fields are part of session_traffic_source_last_click, introduced on 2024-07-17
     , session_traffic_source_last_click.manual_campaign.campaign_id as session_traffic_source_last_click_manual_campaign_id
     , session_traffic_source_last_click.manual_campaign.campaign_name as session_traffic_source_last_click_manual_campaign_name
     , session_traffic_source_last_click.manual_campaign.source as session_traffic_source_last_click_manual_source
@@ -104,15 +110,19 @@
     , session_traffic_source_last_click.manual_campaign.source_platform as session_traffic_source_last_click_manual_source_platform
     , session_traffic_source_last_click.manual_campaign.creative_format as session_traffic_source_last_click_creative_format
     , session_traffic_source_last_click.manual_campaign.marketing_tactic as session_traffic_source_last_click_manual_marketing_tactic
+    {% endif %}
     , collected_traffic_source.manual_campaign_id as collected_traffic_source_manual_campaign_id
     , collected_traffic_source.manual_campaign_name as collected_traffic_source_manual_campaign_name
     , collected_traffic_source.manual_source as collected_traffic_source_manual_source
     , collected_traffic_source.manual_medium as collected_traffic_source_manual_medium
     , collected_traffic_source.manual_term as collected_traffic_source_manual_term
     , collected_traffic_source.manual_content as collected_traffic_source_manual_content
+    {% if var('start_date', '20240101') >= '20240711' %}
+    -- The following manual fields were introduced on 2024-07-11 to enhance marketing campaign tracking
     , collected_traffic_source.manual_source_platform as collected_traffic_source_manual_source_platform
     , collected_traffic_source.manual_creative_format as collected_traffic_source_manual_creative_format
     , collected_traffic_source.manual_marketing_tactic as collected_traffic_source_manual_marketing_tactic
+    {% endif %}
     , collected_traffic_source.gclid as collected_traffic_source_gclid
     , collected_traffic_source.dclid as collected_traffic_source_dclid
     , collected_traffic_source.srsltid as collected_traffic_source_srsltid


### PR DESCRIPTION
…fields introduced on 2024-07-11 and 2024-07-17 based on the start date.

This pull request introduces conditional logic to the `macros/base_select.sql` file to include new fields for enhanced attribution and marketing campaign tracking. The changes ensure that these fields are only included for datasets starting on specific dates, maintaining compatibility with older data.

### Attribution tracking improvements:
* Added the `session_traffic_source_last_click` field, along with its associated subfields, to provide more detailed session-level attribution data. These fields are conditionally included for datasets with a `start_date` on or after 2024-07-17. [[1]](diffhunk://#diff-bc5bd8a851ad0e6990f0e8341ed34380c52fc0d41e0998e5c98ec12ecce6ee44R38-R42) [[2]](diffhunk://#diff-bc5bd8a851ad0e6990f0e8341ed34380c52fc0d41e0998e5c98ec12ecce6ee44R102-R103) [[3]](diffhunk://#diff-bc5bd8a851ad0e6990f0e8341ed34380c52fc0d41e0998e5c98ec12ecce6ee44R113-R125)

### Marketing campaign tracking enhancements:
* Introduced new manual campaign fields (`manual_source_platform`, `manual_creative_format`, and `manual_marketing_tactic`) under `collected_traffic_source` to improve marketing campaign tracking. These fields are conditionally included for datasets with a `start_date` on or after 2024-07-11.

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
